### PR TITLE
7 fix output pixel size to align with window size parameter

### DIFF
--- a/roughness_calculator/classes/application_driver.py
+++ b/roughness_calculator/classes/application_driver.py
@@ -161,6 +161,16 @@ class ApplicationDriver:
         # Update the profile with the provided data type and nodata value
         self.processor.profile.update(dtype=dtype, nodata=nodata)
 
+        # Calculate the new pixel size, width, and height based on the window size
+        pixel_size = self.window_size
+        width = int((self.processor.profile['width'] * self.processor.profile['transform'][0]) / pixel_size)
+        height = int((self.processor.profile['height'] * abs(self.processor.profile['transform'][4])) / pixel_size)
+
+        # Update the transform, width, and height in the profile
+        self.processor.profile['transform'] = rasterio.Affine(pixel_size, 0, self.processor.profile['transform'][2], 0, -pixel_size, self.processor.profile['transform'][5])
+        self.processor.profile['width'] = width
+        self.processor.profile['height'] = height
+
         # Open the output path as a new GeoTIFF file in write mode
         with rasterio.open(output_path, 'w', **self.processor.profile) as dst:
             # Write the processed data to the first band of the GeoTIFF file

--- a/roughness_calculator/classes/application_driver.py
+++ b/roughness_calculator/classes/application_driver.py
@@ -86,7 +86,7 @@ class ApplicationDriver:
 
         logging.info("Processing completed.")
 
-    def produce_preview(self, nodata_value: int = -9999) -> None:
+    def produce_preview(self, nodata_value: int = Defaults.NODATA_VALUE) -> None:
         """
         Generates a preview image from the processed data stored in self.processed_data.
         This method avoids re-reading the data from file, making it more efficient.
@@ -138,7 +138,10 @@ class ApplicationDriver:
             # Raise a new error, preserving the original traceback
             raise RuntimeError("Failed to produce preview due to an error.") from e
 
-    def save_processed_data(self, output_path: str, nodata: int = -9999, dtype: str = Defaults.DTYPE) -> None:
+    def save_processed_data(self,
+                            output_path: str,
+                            nodata: int = Defaults.NODATA_VALUE,
+                            dtype: str = Defaults.DTYPE) -> None:
         """
         Saves the processed data to a GeoTIFF file using the stored profile.
 


### PR DESCRIPTION
**Overview:**
This pull request addresses the issue where the pixel size of the output file was not matching the specified window size parameter. The root of the problem was identified in the `save_processed_data` method of the `ApplicationDriver` class, which was incorrectly using the input file's profile settings for the output file.

**Changes Implemented:**
- Updated the `save_processed_data` method to adjust the transform, width, and height in the profile based on the window size used during processing.
- The new calculations ensure that the output file's pixel dimensions correctly reflect the window size parameter, aligning the output with user expectations and processing parameters.

**Code Snippet:**
```python
def save_processed_data(self, output_path: str, nodata: int = Defaults.NODATA_VALUE, dtype: str = Defaults.DTYPE) -> None:
    # Update profile for output data type and no-data value
    self.processor.profile.update(dtype=dtype, nodata=nodata)

    # Recalculate dimensions based on the window size
    pixel_size = self.window_size
    width = int((self.processor.profile['width'] * self.processor.profile['transform'][0]) / pixel_size)
    height = int((self.processor.profile['height'] * abs(self.processor.profile['transform'][4])) / pixel_size)

    # Update the profile to apply new dimensions and transformations
    self.processor.profile['transform'] = rasterio.Affine(pixel_size, 0, self.processor.profile['transform'][2], 0, -pixel_size, self.processor.profile['transform'][5])
    self.processor.profile['width'] = width
    self.processor.profile['height'] = height

    # Save processed data to the output file
    with rasterio.open(output_path, 'w', **self.processor.profile) as dst:
        dst.write(self.processed_data, 1)

    logging.info(f"Processed data saved to {output_path}")
```

**Impact:**
These changes correct the output file dimensions to match the intended analysis scale, enhancing the accuracy and applicability of the processed data. The fix has been validated and results in the output file correctly representing the set window size parameters.
This solves #7 and #6 

**Additional Information:**
- The commit 9d5cc61966fbcb884f13f01f5009f040dbbaa438 includes all changes.
- See https://github.com/lbatschelet/dem-roughness-calculator/issues/7#issuecomment-2104159476 for further details